### PR TITLE
feat(components/documentation/library): adjust styles to match specs

### DIFF
--- a/components/documentation/library/src/components/Article/Article.styles.scss
+++ b/components/documentation/library/src/components/Article/Article.styles.scss
@@ -1,26 +1,5 @@
 .sui-studio-doc-article {
-  padding: 1em 2em;
-  border-radius: 4px;
-  background: var(--c-sui-studio-doc-neutral0);
-  border-width: 1px;
-  border-style: solid;
-  border-color: var(--c-sui-studio-doc-neutral0);
-  &.sui-studio-doc-article-mode-dark {
-    border-width: 1px;
-    border-style: solid;
-    border-color: var(--c-sui-studio-doc-neutral10);
-    background: var(--c-sui-studio-doc-neutral10);
-  }
-  &.sui-studio-doc-article-outline {
-    background: var(--c-sui-studio-doc-neutral0);
-    border-width: 1px;
-    border-style: solid;
-    border-color: var(--c-sui-studio-doc-neutral10);
-    &.sui-studio-doc-article-mode-dark {
-      border-color: var(--c-sui-studio-doc-neutral0);
-      background: var(--c-sui-studio-doc-neutral10);
-    }
-  }
+  // just a blank article, no style
   &-full-screen {
     width: 100vw;
     height: 100vh;

--- a/components/documentation/library/src/components/Base.scss
+++ b/components/documentation/library/src/components/Base.scss
@@ -81,7 +81,7 @@
     }
     &-mode {
       &-light {
-        color: var(--c-sui-studio-doc-neutral10);
+        color: var(--c-sui-studio-doc-neutral7);
       }
       &-dark {
         color: var(--c-sui-studio-doc-neutral0);

--- a/components/documentation/library/src/components/Box/Box.styles.scss
+++ b/components/documentation/library/src/components/Box/Box.styles.scss
@@ -1,26 +1,17 @@
 .sui-studio-doc-box {
-  padding: 1em 2em;
+  padding: 1rem;
   border-radius: 4px;
   background: var(--c-sui-studio-doc-neutral0);
   border-width: 1px;
   border-style: solid;
-  border-color: var(--c-sui-studio-doc-neutral0);
+  border-color: var(--c-sui-studio-doc-neutral2);
   &.sui-studio-doc-box-mode-dark {
-    border-width: 1px;
-    border-style: solid;
-    border-color: var(--c-sui-studio-doc-neutral10);
     background: var(--c-sui-studio-doc-neutral10);
-  }
-  &.sui-studio-doc-box-outline {
-    background: var(--c-sui-studio-doc-neutral0);
     border-width: 1px;
     border-style: solid;
-    border-color: var(--c-sui-studio-doc-neutral10);
-    &.sui-studio-doc-box-mode-dark {
-      border-color: var(--c-sui-studio-doc-neutral0);
-      background: var(--c-sui-studio-doc-neutral10);
-    }
+    border-color: var(--c-sui-studio-doc-neutral7);
   }
+
   &-full-screen {
     width: 100vw;
     height: 100vh;

--- a/components/documentation/library/src/components/Code/Code.styles.scss
+++ b/components/documentation/library/src/components/Code/Code.styles.scss
@@ -1,19 +1,16 @@
 .sui-studio-doc.sui-studio-doc-code {
-  color: var(--c-sui-studio-doc-secondary5);
-  font-size: 0.9em;
+  color: var(--c-sui-studio-doc-secondary);
+  font-size: 0.9rem;
   font-family: var(--ff-sui-studio-doc-monospace);
   font-weight: var(--fw-sui-studio-doc-regular);
-  background: var(--c-sui-studio-doc-neutral0);
-  border: solid 1px var(--c-sui-studio-doc-neutral2);
   border-radius: 4px;
-  padding: 0 2px;
+  padding: 2px 4px;
   &.sui-studio-doc-mode-light {
-    background: var(--c-sui-studio-doc-neutral0);
-    border: solid 1px var(--c-sui-studio-doc-neutral2);
-    color: var(--c-sui-studio-doc-secondary5);
+    color: var(--c-sui-studio-doc-secondary);
+    background: hsl(var(--c-palette-neutral-hue), 0%, 95%);
   }
   &.sui-studio-doc-mode-dark {
+    color: var(--c-sui-studio-doc-secondary);
     background: var(--c-sui-studio-doc-neutral-darkest);
-    border: solid 1px var(--c-sui-studio-doc-neutral);
   }
 }

--- a/components/documentation/library/src/components/Heading/Heading.styles.scss
+++ b/components/documentation/library/src/components/Heading/Heading.styles.scss
@@ -1,29 +1,33 @@
 .sui-studio-doc.sui-studio-doc-heading {
-  margin: 0.8em 0 0.2em 0;
+  margin: 0;
+  margin-bottom: 0.4rem;
   font-family: var(--ff-sui-studio-doc-sans-serif);
   @at-root {
     &-h1,
     h1#{&} {
       font-size: var(--fz-sui-studio-doc-xxl);
-      font-weight: var(--fw-sui-studio-doc-black);
+      font-weight: var(--fw-sui-studio-doc-regular);
+      border-bottom: 1px solid var(--c-sui-studio-doc-neutral1);
     }
 
     &-h2,
     h2#{&} {
-      font-size: var(--fz-sui-studio-doc-xl);
+      font-size: var(--fz-sui-studio-doc-xs);
       font-weight: var(--fw-sui-studio-doc-bold);
+      text-transform: var(--tt-sui-studio-doc-uppercase);
+      margin-top: 3.5rem;
     }
 
     &-h3,
     h3#{&} {
-      font-size: var(--fz-sui-studio-doc-lg);
-      font-weight: var(--fw-sui-studio-doc-bold);
+      font-size: var(--fz-sui-studio-doc-sm);
+      font-weight: var(--fw-sui-studio-doc-regular);
     }
 
     &-h4,
     h4#{&} {
-      font-size: var(--fz-sui-studio-doc-md);
-      font-weight: var(--fw-sui-studio-doc-bold);
+      font-size: var(--fz-sui-studio-doc-xs);
+      font-weight: var(--fw-sui-studio-doc-regular);
     }
   }
 }

--- a/components/documentation/library/src/components/Paragraph/Paragraph.styles.scss
+++ b/components/documentation/library/src/components/Paragraph/Paragraph.styles.scss
@@ -1,3 +1,5 @@
 .sui-studio-doc.sui-studio-doc-paragraph {
-  // eslint-disable
+  font-size: 1rem;
+  font-weight: var(--fw-sui-studio-doc-regular);
+  color: var(--c-sui-studio-doc-neutral6);
 }

--- a/components/documentation/library/src/components/Quote/Quote.styles.scss
+++ b/components/documentation/library/src/components/Quote/Quote.styles.scss
@@ -1,5 +1,7 @@
 .sui-studio-doc.sui-studio-doc-quote {
-  font-size: var(--fz-sui-studio-doc-md);
+  font-size: var(--fz-sui-studio-doc-sm);
   font-weight: var(--fw-sui-studio-doc-regular);
-  font-style: var(--fs-sui-studio-doc-italic);
+  border-left: 0.25rem solid var(--c-sui-studio-doc-neutral1);
+  color: var(--c-sui-studio-doc-neutral4);
+  padding: 0 1rem;
 }

--- a/components/documentation/library/src/styles/font.scss
+++ b/components/documentation/library/src/styles/font.scss
@@ -7,12 +7,12 @@
     'Segoe UI Symbol';
 
   // FONT-SIZE fz
-  --fz-sui-studio-doc-xs: 0.8em;
-  --fz-sui-studio-doc-sm: 1em;
-  --fz-sui-studio-doc-md: 1.25em;
-  --fz-sui-studio-doc-lg: 1.5em;
-  --fz-sui-studio-doc-xl: 2em;
-  --fz-sui-studio-doc-xxl: 2.5em;
+  --fz-sui-studio-doc-xs: 0.875rem;
+  --fz-sui-studio-doc-sm: 1rem;
+  --fz-sui-studio-doc-md: 1.2rem;
+  --fz-sui-studio-doc-lg: 1.5rem;
+  --fz-sui-studio-doc-xl: 2rem;
+  --fz-sui-studio-doc-xxl: 2.25rem;
 
   // FONT-STRECH fst
   --fst-sui-studio-doc-ultra-condensed: ultra-condensed;


### PR DESCRIPTION
Adjust the styles to match Styles from Figma components template.

**Find the correct specs here:**
https://www.figma.com/file/gwZ74U8HHbPl3l5vbwHHrO/Template---Specs-for-Components?node-id=1885%3A1654

**The result of this change is this:**

![before after](https://user-images.githubusercontent.com/23620759/195643561-2323ce4b-8421-4a9c-9c1b-7fec396e6e04.png)
